### PR TITLE
Improve BGRT image position calculation and add '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/
+pkg/
+*.pkg.tar.*

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname='bootsplash-theme-bgrt'
-pkgver=0.1
+pkgver=0.2
 pkgrel=1
 pkgdesc="BGRT bootsplash theme"
 url="https://github.com/t1meshift/bootsplash-theme-bgrt"

--- a/bootsplash-bgrt.sh
+++ b/bootsplash-bgrt.sh
@@ -17,6 +17,7 @@ fi
 LOGO=logo.bmp
 LOGO_WIDTH=$(identify $LOGO | cut -d " " -f 3 | cut -d x -f 1)
 LOGO_HEIGHT=$(identify $LOGO | cut -d " " -f 3 | cut -d x -f 2)
+LOGO_OFFSET=$(cat /sys/firmware/acpi/bgrt/yoffset)
 
 THROBBER=spinner.gif
 THROBBER_WIDTH=$(identify $THROBBER | head -1 | cut -d " " -f 3 | \
@@ -43,7 +44,8 @@ convert -alpha remove \
 	--picture \
 	--pic_width $LOGO_WIDTH \
 	--pic_height $LOGO_HEIGHT \
-	--pic_position 0 \
+	--pic_position 0x11 \
+	--pic_position_offset $LOGO_OFFSET \
 	--blob logo.rgb \
 	--picture \
 	--pic_width $THROBBER_WIDTH \


### PR DESCRIPTION
Following PR has 2 changes which I personally find useful – first tries to properly calculate the Y position of the image, based on the offset from `/sys/firmware/acpi/bgrt/yoffset` and the second one implements a simple `.gitignore` file that makes `git` ignore build files produced by `makepkg`.

I've also bumped the minior version of the package in the `PKGBUILD`.